### PR TITLE
[WIP] Support Composer 2.0 plugin API changes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "composer-plugin-api": "^1.1",
+        "composer-plugin-api": "^1.1||^2.0",
         "php": ">=7.2.0"
     },
     "require-dev": {

--- a/src/MergePlugin.php
+++ b/src/MergePlugin.php
@@ -135,12 +135,33 @@ class MergePlugin implements PluginInterface, EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
+    public function deactivate(Composer $composer, IOInterface $io)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function uninstall(Composer $composer, IOInterface $io)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public static function getSubscribedEvents()
     {
+        if (defined('InstallerEvents::PRE_OPERATIONS_EXEC')) {
+            // composer-plugin-api ^2.0
+            $installerStartEvent = InstallerEvents::PRE_OPERATIONS_EXEC;
+        } else {
+            // composer-plugin-api ^1.0
+            $installerStartEvent = InstallerEvents::PRE_DEPENDENCIES_SOLVING;
+        }
         return array(
             PluginEvents::INIT =>
                 array('onInit', self::CALLBACK_PRIORITY),
-            InstallerEvents::PRE_DEPENDENCIES_SOLVING =>
+            $installerStartEvent =>
                 array('onDependencySolve', self::CALLBACK_PRIORITY),
             PackageEvents::POST_PACKAGE_INSTALL =>
                 array('onPostPackageInstall', self::CALLBACK_PRIORITY),


### PR DESCRIPTION
Add initial support for the upcoming Composer 2.0 release:
* Allow either ^1.1 or ^2.0 composer-plugin-api
* Implement new PluginInterface methods (as no-op)
* Prefer InstallerEvents::PRE_OPERATIONS_EXEC over
  InstallerEvents::PRE_DEPENDENCIES_SOLVING when available

Bug: T248908
Co-authored-by: Bryan Davis <bd808@wikimedia.org>